### PR TITLE
Adding dcrypto support with userspace library.

### DIFF
--- a/golf2/Makefile
+++ b/golf2/Makefile
@@ -1,4 +1,4 @@
-APP ?= blink
+APP ?= dcrypto_test
 TOCK_ARCH = cortex-m3
 TARGET = thumbv7m-none-eabi
 PLATFORM = golf2

--- a/golf2/apps/dcrypto_test/Makefile
+++ b/golf2/apps/dcrypto_test/Makefile
@@ -1,0 +1,17 @@
+CURRENT_DIR := $(dir $(abspath $(lastword $(MAKEFILE_LIST))))
+
+TOCK_ARCH ?= cortex-m3
+TOCK_USERLAND_BASE_DIR = $(CURRENT_DIR)../../../tock/userland
+BUILDDIR ?= $(CURRENT_DIR)/build/$(TOCK_ARCH)
+
+C_SRCS   := $(wildcard *.c)
+
+OBJS += $(patsubst %.c,$(BUILDDIR)/%.o,$(C_SRCS))
+
+CPPFLAGS += -DSTACK_SIZE=2048
+
+include $(TOCK_USERLAND_BASE_DIR)/AppMakefile.mk
+
+$(BUILDDIR)/%.o: %.c | $(BUILDDIR)
+	$(CC) $(CFLAGS) $(CPPFLAGS) -c -o $@ $<
+

--- a/golf2/apps/dcrypto_test/dcrypto.c
+++ b/golf2/apps/dcrypto_test/dcrypto.c
@@ -1,0 +1,63 @@
+#include <tock.h>
+#include "dcrypto.h"
+
+
+int last_error = 0;
+int last_fault = 0;
+
+static void tock_dcrypto_run_done(int error,
+			      int fault,
+			      int unused __attribute__((unused)),
+			      void *callback_args) {
+  last_error = error;
+  last_fault = fault;
+  *(bool*)callback_args = true;
+}
+
+
+
+int tock_dcrypto_run(void* data, size_t datalen,
+		     void* program, size_t programlen) {
+
+  int ret = -1;
+  bool run_done = false;
+    
+  ret = subscribe(HOTEL_DRIVER_DCRYPTO, TOCK_DCRYPTO_RUN_DONE,
+		  tock_dcrypto_run_done, &run_done);
+  if (ret < 0) {
+    printf("Could not register dcrypto callback with kernel: %d\n", ret);
+    return ret;
+  }
+
+  ret = allow(HOTEL_DRIVER_DCRYPTO, TOCK_DCRYPTO_ALLOW_DATA,
+	      data, datalen);
+  if (ret < 0) {
+
+    printf("Could not give kernel access to dcrypto data: %d\n", ret);
+    return ret;
+  }
+
+  ret = allow(HOTEL_DRIVER_DCRYPTO, TOCK_DCRYPTO_ALLOW_PROG,
+	      program, programlen);
+  if (ret < 0) {
+    printf("Could not give kernel access to dcrypto program: %d\n", ret);
+    return ret;
+  }
+
+  ret = command(HOTEL_DRIVER_DCRYPTO, TOCK_DCRYPTO_CMD_RUN, 0, 0);
+
+  if (ret < 0) {
+    printf("Could not invoke dcrypto program with command: %d\n", ret);
+    return ret;
+  }
+
+  yield_for(&run_done);
+
+  if (last_error != 0) {
+    printf("DCRYPTO failed with fault %i.\n", last_fault);
+    return last_fault;
+  } else {
+    return 0;
+  }
+}
+

--- a/golf2/apps/dcrypto_test/dcrypto.c
+++ b/golf2/apps/dcrypto_test/dcrypto.c
@@ -5,6 +5,29 @@
 int last_error = 0;
 int last_fault = 0;
 
+const char* TOCK_DCRYPTO_ERRORS[] = {
+			       "?",
+			       "?",
+			       "call stack overflow",
+			       "loop stack underflow",
+			       "loop stack overflow",
+			       "data access",
+			       "?",
+			       "break",
+			       "trap",
+			       "?",
+			       "fault",
+			       "loop mod operand range",
+			       "unknown"};
+
+static const char* tock_dcrypto_fault_to_str(int fault) {
+    if (fault <= TOCK_DCRYPTO_FAULT_UNKNOWN) {
+      return TOCK_DCRYPTO_ERRORS[fault];
+    } else {
+      return "?";
+    }
+}
+
 static void tock_dcrypto_run_done(int error,
 			      int fault,
 			      int unused __attribute__((unused)),
@@ -32,16 +55,19 @@ int tock_dcrypto_run(void* data, size_t datalen,
   ret = allow(HOTEL_DRIVER_DCRYPTO, TOCK_DCRYPTO_ALLOW_DATA,
 	      data, datalen);
   if (ret < 0) {
-
+    // This should only occur if application state is not available,
+    // which means the driver is busy.
     printf("Could not give kernel access to dcrypto data: %d\n", ret);
-    return ret;
+    return TOCK_EBUSY;
   }
 
   ret = allow(HOTEL_DRIVER_DCRYPTO, TOCK_DCRYPTO_ALLOW_PROG,
 	      program, programlen);
   if (ret < 0) {
+    // This should only occur if application state is not available,
+    // which means the driver is busy.
     printf("Could not give kernel access to dcrypto program: %d\n", ret);
-    return ret;
+    return TOCK_EBUSY;
   }
 
   ret = command(HOTEL_DRIVER_DCRYPTO, TOCK_DCRYPTO_CMD_RUN, 0, 0);
@@ -54,7 +80,7 @@ int tock_dcrypto_run(void* data, size_t datalen,
   yield_for(&run_done);
 
   if (last_error != 0) {
-    printf("DCRYPTO failed with fault %i.\n", last_fault);
+    printf("\nDCRYPTO failed: %s (%i).\n", tock_dcrypto_fault_to_str(last_fault), last_fault);
     return last_fault;
   } else {
     return 0;

--- a/golf2/apps/dcrypto_test/dcrypto.h
+++ b/golf2/apps/dcrypto_test/dcrypto.h
@@ -1,0 +1,30 @@
+#ifndef TOCK_DCRYPTO_H
+#define TOCK_DCRYPTO_H
+
+#include <stdlib.h>
+
+#define HOTEL_DRIVER_DCRYPTO 0x40004
+
+#define TOCK_DCRYPTO_CMD_CHECK 0
+#define TOCK_DCRYPTO_CMD_RUN   1
+
+#define TOCK_DCRYPTO_ALLOW_DATA 0
+#define TOCK_DCRYPTO_ALLOW_PROG 1
+
+#define TOCK_DCRYPTO_RUN_DONE 0
+
+
+// Run the program pointed to by program with the data pointed to by
+// data as data memory. The lengths are in bytes, but only whole
+// 4-byte words are used: partial words are not used. For example,
+// calling tock_dcrypto_run with a datalen of 11 will result in only 8
+// bytes of data being copied in and out from dcrypto memory, while
+// calling it with a datalen of 12 will result in 12 bytes being
+// copied in/out.
+//
+// While the function does not accept partial words, it does not assume
+// alignment: data and program do not have to be word-aligned.
+int tock_dcrypto_run(void* data, size_t datalen,
+		     void* program, size_t programlen);
+
+#endif

--- a/golf2/apps/dcrypto_test/dcrypto.h
+++ b/golf2/apps/dcrypto_test/dcrypto.h
@@ -13,7 +13,16 @@
 
 #define TOCK_DCRYPTO_RUN_DONE 0
 
-
+#define TOCK_DCRYPTO_FAULT_STACK_OVERFLOW  2
+#define TOCK_DCRYPTO_FAULT_LOOP_OVERFLOW   3
+#define TOCK_DCRYPTO_FAULT_LOOP_UNDERFLOW  4
+#define TOCK_DCRYPTO_FAULT_DATA_ACCESS     5
+#define TOCK_DCRYPTO_FAULT_BREAK           7
+#define TOCK_DCRYPTO_FAULT_TRAP            8
+#define TOCK_DCRYPTO_FAULT_FAULT          10
+#define TOCK_DCRYPTO_FAULT_LOOP_MODRANGE  11
+#define TOCK_DCRYPTO_FAULT_UNKNOWN        12
+			       
 // Run the program pointed to by program with the data pointed to by
 // data as data memory. The lengths are in bytes, but only whole
 // 4-byte words are used: partial words are not used. For example,

--- a/golf2/apps/dcrypto_test/main.c
+++ b/golf2/apps/dcrypto_test/main.c
@@ -36,17 +36,17 @@ int main(void) {
   
   printf("==== Running DCRYPTO ====\n");
 
-  printf("Testing simple return program: should succeed.\n");
+  printf("1. Testing simple return program: should succeed.\n");
   ret = tock_dcrypto_run(data, 10, program_return, 4);
   printf("Return value: %i.\n", ret);
   printf("\n");
-  delay_ms(500);
+  delay_ms(1000);
     
-  printf("Testing infinite recursion program: should terminate with overflow.\n");
+  printf("2. Testing infinite recursion: should overflow.\n");
   ret = tock_dcrypto_run(data, 10, program_recursion, 8);
-  printf("Return value: %i.\n", ret);
-  printf("\n");
-  delay_ms(500);
+  //printf("Return value: %i.\n", ret);
+  //printf("\n");
+
   /*
   printf("Expecting [%d]: 0x", sizeof(expected));
   print_buffer(expected, sizeof(expected), "%02x");

--- a/golf2/apps/dcrypto_test/main.c
+++ b/golf2/apps/dcrypto_test/main.c
@@ -1,0 +1,91 @@
+#include <stdio.h>
+#include <string.h>
+#include <timer.h>
+
+#include "dcrypto.h"
+
+static char program_return[] = {0x00, 0x00, 0x00, 0x0c}; // RET
+static char program_recursion[] = {0x00, 0x00, 0x00, 0x08,  // CALL 0
+                                   0x00, 0x00, 0x00, 0x00}; // BREAK
+ 
+static char data[] = "Data to encrypt. We shall see if this works.";
+/* static char key[] = "1234567890123456";
+static char expected[] = {
+    0x25, 0x97, 0xea, 0xce, 0x3a, 0x51, 0xce, 0x0d, 0xd8, 0x97, 0xae, 0x00,
+    0x2a, 0x4e, 0xcd, 0xac, 0xe6, 0x31, 0xf6, 0x42, 0xa3, 0xbe, 0x5f, 0xaf,
+    0x3e, 0x8f, 0x04, 0x39, 0xf5, 0x9c, 0x40, 0x96, 0x6f, 0x21, 0x4b, 0xce,
+    0x1a, 0x1f, 0xbc, 0xdf, 0x95, 0x26, 0xc4, 0xf1, 0xff, 0xed, 0xf1, 0x22};
+
+static char output[8000 / 8];
+static char decrypted[8000 / 8];*/
+
+
+
+void print_buffer(char *buffer, size_t length, const char *format);
+
+void print_buffer(char *buffer, size_t length, const char *format) {
+  for (size_t i = 0; i < length; i++) {
+    printf(format, buffer[i]);
+    fflush(stdout);
+  }
+  printf("\n");
+}
+
+int main(void) {
+  int ret = 0;
+  
+  printf("==== Running DCRYPTO ====\n");
+
+  printf("Testing simple return program: should succeed.\n");
+  ret = tock_dcrypto_run(data, 10, program_return, 4);
+  printf("Return value: %i.\n", ret);
+  printf("\n");
+  delay_ms(500);
+    
+  printf("Testing infinite recursion program: should terminate with overflow.\n");
+  ret = tock_dcrypto_run(data, 10, program_recursion, 8);
+  printf("Return value: %i.\n", ret);
+  printf("\n");
+  delay_ms(500);
+  /*
+  printf("Expecting [%d]: 0x", sizeof(expected));
+  print_buffer(expected, sizeof(expected), "%02x");
+  printf("Setting up key.\n");
+  tock_aes_setup(key, strlen(key), TOCK_AES_SIZE_128, TOCK_AES_ENCRYPT);
+  printf("Encrypting.\n");
+  int len = tock_aes_crypt(data, strlen(data), output, sizeof(output));
+  tock_aes_finish();
+
+  if (len >= 0) {
+    printf("Result    [%d]: 0x", len);
+    print_buffer(output, len, "%02x");
+  } else {
+    printf("Got error while encrypting: %d\n", -len);
+    return -1;
+  }
+  
+  printf("\n");
+  printf("==== Starting Decryption ====\n");
+
+  printf("Expecting [%d]: ", sizeof(data));
+  print_buffer(data, strlen(data), "%c");
+
+  int res;
+  printf("Setting up key.\n");
+  res = tock_aes_setup(key, strlen(key), TOCK_AES_SIZE_128, TOCK_AES_DECRYPT);
+  if (res < 0) {
+    printf("Got error while setup: %d\n", res);
+  }
+  printf("Decrypting.\n");
+  int dec_len = tock_aes_crypt(output, len, decrypted, sizeof(decrypted));
+  tock_aes_finish();
+
+  if (dec_len >= 0) {
+    printf("Result    [%d]: ", dec_len);
+    print_buffer(decrypted, dec_len, "%c");
+  } else {
+    printf("Got error while decrypting: %d\n", -dec_len);
+    return -1;
+  }
+  */
+}

--- a/golf2/src/dcrypto.rs
+++ b/golf2/src/dcrypto.rs
@@ -95,7 +95,7 @@ impl<'a> Driver for DcryptoDriver<'a> {
                 if self.busy.get() { 
                     ReturnCode::EBUSY
                 } else {
-                    self.app.map_or(ReturnCode::FAIL, |app| {
+                    self.app.map_or(ReturnCode::EBUSY, |app| {
                         self.busy.set(true);
                         self.run_program(app)
                     })

--- a/golf2/src/dcrypto.rs
+++ b/golf2/src/dcrypto.rs
@@ -1,0 +1,162 @@
+use core::cell::Cell;
+use hotel::crypto::dcrypto::{Dcrypto, DcryptoClient, ProgramFault};
+use kernel::{AppId, Callback, Driver, ReturnCode, Shared, AppSlice};
+use kernel::common::take_cell::{MapCell};
+
+pub const DRIVER_NUM: usize = 0x40004;
+
+pub struct App {
+    program: Option<AppSlice<Shared, u8>>,
+    data_buffer: Option<AppSlice<Shared, u8>>,
+    callback: Option<Callback>,
+}
+
+impl Default for App {
+    fn default() -> App {
+        App {
+            program: None,
+            data_buffer: None,
+            callback: None
+        }
+    }
+}
+
+pub struct DcryptoDriver<'a> {
+    device: &'a Dcrypto<'a>,
+    app: MapCell<App>,
+    current_user: Cell<Option<AppId>>,
+    busy: Cell<bool>,
+}
+
+impl<'a> DcryptoDriver<'a> {
+    pub fn new(device: &'a mut Dcrypto<'a>) -> DcryptoDriver<'a> {
+        DcryptoDriver {
+            device: device,
+            current_user: Cell::new(None),
+            app: MapCell::new(App::default()),
+            busy: Cell::new(false),
+       }
+    }
+    
+    fn run_program(&self, app: &mut App) -> ReturnCode {
+        if app.data_buffer.is_none() || app.program.is_none() {
+            return ReturnCode::ENOMEM;
+        }
+        
+        let mut rval = ReturnCode::SUCCESS;
+        let data_slice = app.data_buffer.take().unwrap();
+        let program_slice = app.program.take().unwrap();
+        {
+            // In user space, len is in bytes. For the device, however,
+            // len is in terms of words, with partial words being truncated.
+            // So divide by 4.
+            let data = data_slice.as_ref();
+            let data_len = data.len() / 4;
+            let program = program_slice.as_ref();
+            let program_len = program.len() / 4;
+            
+            rval = self.device.write_data(data, 0, data_len as u32);
+
+            if rval == ReturnCode::SUCCESS {
+                rval = self.device.write_instructions(program, 0, program_len as u32);
+            }
+        };
+        app.data_buffer = Some(data_slice);
+        app.program = Some(program_slice);
+
+        if rval != ReturnCode::SUCCESS {
+            return rval;
+        }
+        rval = self.device.call_imem(0);
+        if rval != ReturnCode::SUCCESS {
+            return rval;
+        }
+        ReturnCode::SUCCESS
+    }
+}
+
+impl<'a> Driver for DcryptoDriver<'a> {
+    fn subscribe(&self, subscribe_num: usize, callback: Callback) -> ReturnCode {
+        match subscribe_num {
+            0 => {
+                self.app.map(|app| {
+                    app.callback = Some(callback);
+                });
+                ReturnCode::SUCCESS
+            },
+            _ => ReturnCode::ENOSUPPORT
+        }
+    }
+
+    fn command(&self, command_num: usize, arg1: usize, _: usize, caller_id: AppId) -> ReturnCode {
+        match command_num {
+            0 /* Check if present */ => ReturnCode::SUCCESS,            
+            1 /* run program */ => {
+                if self.busy.get() { 
+                    ReturnCode::EBUSY
+                } else {
+                    self.app.map_or(ReturnCode::FAIL, |app| {
+                        self.busy.set(true);
+                        self.run_program(app)
+                    })
+                }
+            }
+            _ => ReturnCode::ENOSUPPORT,
+        }
+    }
+    
+    fn allow(&self, app_id: AppId, minor_num: usize, slice: AppSlice<Shared, u8>) -> ReturnCode {
+        match minor_num {
+            0 => {
+                // Data memory
+                self.app
+                    .map(|app_data| {
+                        app_data.data_buffer = Some(slice);
+                        ReturnCode::SUCCESS
+                    })
+                    .unwrap_or(ReturnCode::FAIL)
+            }
+            1 => {
+                // Input Buffer
+                self.app
+                    .map(|app_data| {
+                        app_data.program = Some(slice);
+                        ReturnCode::SUCCESS
+                    })
+                    .unwrap_or(ReturnCode::FAIL)
+            }
+            _ => ReturnCode::ENOSUPPORT,
+        }
+    }
+}
+
+impl<'a> DcryptoClient<'a> for DcryptoDriver<'a> {
+    fn execution_complete(&self, error: ReturnCode, fault: ProgramFault) {
+        self.busy.set(false);
+        self.app.map(move |app| {
+            app.callback.map(|mut callback| {
+                let mut data_slice = app.data_buffer.take().unwrap();
+                {
+                    let data = data_slice.as_mut();
+                    // In user space, len is in bytes. For the device,
+                    // however, len is in terms of words, with partial
+                    // words being truncated.  So divide by 4.
+                    let len = (data.len() / 4) as u32;
+                    self.device.read_data(data, 0, len);
+                    callback.schedule(usize::from(error), usize::from(fault), 0);
+                }
+                app.data_buffer = Some(data_slice);
+            });
+        });
+    }
+
+    fn reset_complete(&self, _error: ReturnCode) {
+        panic!("ERROR: Dcrypto driver reset_complete invoked, but should never be called.");
+    }
+
+    fn secret_wipe_complete(&self, _error: ReturnCode) {
+        panic!("ERROR: Dcrypto driver secret_wipe_complete invoked, but should never be called.");
+    }
+
+
+}

--- a/golf2/src/main.rs
+++ b/golf2/src/main.rs
@@ -126,11 +126,11 @@ pub unsafe fn reset_handler() {
 
     hotel::crypto::dcrypto::DCRYPTO.initialize();
     let dcrypto = static_init!(
-        dcrypto::DcryptoDriver,
+        dcrypto::DcryptoDriver<'static>,
         dcrypto::DcryptoDriver::new(&mut hotel::crypto::dcrypto::DCRYPTO),
     24);
     
-    //hotel::crypto::dcrypto::DCRYPTO.set_client(dcrypto);
+    hotel::crypto::dcrypto::DCRYPTO.set_client(dcrypto);
         
     /*    hotel::trng::TRNG0.init();
     let rng = static_init!(
@@ -171,7 +171,7 @@ pub unsafe fn reset_handler() {
     let mut chip = hotel::chip::Hotel::new();
     chip.mpu().enable_mpu();
 
-    dcrypto_test::run_dcrypto();
+// dcrypto_test::run_dcrypto();
 //    rng_test::run_rng();
 
     extern "C" {
@@ -198,12 +198,13 @@ impl Platform for Golf {
         match driver_num {
             capsules::console::DRIVER_NUM => f(Some(self.console)),
             capsules::gpio::DRIVER_NUM    => f(Some(self.gpio)),
-            digest::DRIVER_NUM             => f(Some(self.digest)),
-            capsules::alarm::DRIVER_NUM => f(Some(self.timer)),
-            aes::DRIVER_NUM   => f(Some(self.aes)),
+            digest::DRIVER_NUM            => f(Some(self.digest)),
+            capsules::alarm::DRIVER_NUM   => f(Some(self.timer)),
+            aes::DRIVER_NUM               => f(Some(self.aes)),
 //            capsules::rng::DRIVER_NUM   => f(Some(self.rng)),
-            kernel::ipc::DRIVER_NUM     => f(Some(&self.ipc)),
-            _ => f(None),
+            kernel::ipc::DRIVER_NUM       => f(Some(&self.ipc)),
+            dcrypto::DRIVER_NUM           => f(Some(self.dcrypto)),
+            _ =>  f(None),
         }
     }
 }

--- a/hotel/src/crypto/dcrypto.rs
+++ b/hotel/src/crypto/dcrypto.rs
@@ -343,7 +343,7 @@ impl<'a> DcryptoEngine<'a> {
             11 => ProgramFault::Trap,
             _ => ProgramFault::Unknown,
         };
-        println!("DCRYPTO handling {:?} error interrupt.", cause);
+//        println!("DCRYPTO handling {:?} error interrupt.", cause);
 
         // Clear the corresponding interrupt flag
         let flag = match nvic {

--- a/hotel/src/lib.rs
+++ b/hotel/src/lib.rs
@@ -115,10 +115,7 @@ pub unsafe fn init() {
     cortexm3::nvic::enable_all();
 
     // Disable DCRYPTO program receive interrupt
-    let received = cortexm3::nvic::Nvic::new(5);
-    received.disable();
-    let received2 = cortexm3::nvic::Nvic::new(6);
-    received2.disable();
+    cortexm3::nvic::Nvic::new(5).disable();
 }
 
 unsafe extern "C" fn hard_fault_handler() {

--- a/hotel/src/test_dcrypto.rs
+++ b/hotel/src/test_dcrypto.rs
@@ -31,10 +31,10 @@ impl<'a> TestDcrypto<'a> {
     fn start_test_exec(&self) {
         self.case.set(TestCase::SuccessfulExecution);
         println!("DCRYPTO Testing single-instruction program that returns.");
-        static INSTRUCTIONS: [u32; 1] = [
-            0x0c000000, // RET
+        static INSTRUCTIONS: [u8; 4] = [
+            0x00, 0x00, 0x00, 0x0c, // RET
         ];
-        self.dcrypto.write_instructions(&INSTRUCTIONS, 0, 1);
+        self.dcrypto.write_instructions(&INSTRUCTIONS, 0, 4);
         self.dcrypto.call_imem(0);
     }
 
@@ -49,13 +49,13 @@ impl<'a> TestDcrypto<'a> {
     fn start_test_stack(&self) {
         self.case.set(TestCase::StackError);
         println!("DCRYPTO Testing program that overflows call stack.");
-        static INSTRUCTIONS: [u32; 2] = [
+        static INSTRUCTIONS: [u8; 8] = [
             // This instruction just calls itself: it's an infinitely
             // recursive program.
-            0x08000000, // CALL 0
-            0x08000000, // CALL 0
+            0x00, 0x00, 0x00, 0x08, // CALL 0
+            0x00, 0x00, 0x00, 0x08  // CALL 0
         ];
-        self.dcrypto.write_instructions(&INSTRUCTIONS, 0, 2);
+        self.dcrypto.write_instructions(&INSTRUCTIONS, 0, 8);
         self.dcrypto.call_imem(0);
     }
 

--- a/hotel/src/test_dcrypto.rs
+++ b/hotel/src/test_dcrypto.rs
@@ -51,9 +51,13 @@ impl<'a> TestDcrypto<'a> {
         println!("DCRYPTO Testing program that overflows call stack.");
         static INSTRUCTIONS: [u8; 8] = [
             // This instruction just calls itself: it's an infinitely
-            // recursive program.
+            // recursive program. It should trigger a PC stack overflow
+            // error.
+            //
+            // Following it with a BREAK instruction prevents
+            // a subsequent TRAP interrupt, I do not know why. -pal
             0x00, 0x00, 0x00, 0x08, // CALL 0
-            0x00, 0x00, 0x00, 0x08  // CALL 0
+            0x00, 0x00, 0x00, 0x00, // BREAK
         ];
         self.dcrypto.write_instructions(&INSTRUCTIONS, 0, 8);
         self.dcrypto.call_imem(0);

--- a/hotel/src/test_dcrypto.rs
+++ b/hotel/src/test_dcrypto.rs
@@ -1,30 +1,96 @@
 //! Test DCRYPTO hardware
 
+use core::cell::Cell;
+use crypto::dcrypto::{Dcrypto, DcryptoClient, DcryptoEngine, ProgramFault};
 use kernel::returncode::ReturnCode;
-#[allow(unused_imports)]
-use crypto::dcrypto::{Dcrypto, DcryptoClient, DcryptoEngine};
+
+#[derive(Clone, Copy, Debug, PartialEq)]
+enum TestCase {
+    None,
+    SuccessfulExecution,
+    StackError,
+}
 
 pub struct TestDcrypto<'a> {
     dcrypto: &'a DcryptoEngine<'a>,
+    case: Cell<TestCase>,
 }
 
 impl<'a> TestDcrypto<'a> {
     pub fn new(d: &'a DcryptoEngine<'a>) -> Self {
-        TestDcrypto { dcrypto: d }
+        TestDcrypto {
+            dcrypto: d,
+            case: Cell::new(TestCase::None),
+        }
     }
 
     pub fn run(&self) {
+        self.start_test_exec();
+    }
+
+    fn start_test_exec(&self) {
+        self.case.set(TestCase::SuccessfulExecution);
+        println!("DCRYPTO Testing single-instruction program that returns.");
         static INSTRUCTIONS: [u32; 1] = [
             0x0c000000, // RET
         ];
         self.dcrypto.write_instructions(&INSTRUCTIONS, 0, 1);
         self.dcrypto.call_imem(0);
     }
+
+    fn complete_test_exec(&self, error: ReturnCode, fault: ProgramFault) {
+        if error == ReturnCode::SUCCESS {
+            println!("DCRYPTO pass: Program completed with ReturnCode {:?}.", error);
+        } else {
+            println!("DCRYPTO fail: Program completed with fault {:?}.", fault);
+        }
+    }
+
+    fn start_test_stack(&self) {
+        self.case.set(TestCase::StackError);
+        println!("DCRYPTO Testing program that overflows call stack.");
+        static INSTRUCTIONS: [u32; 2] = [
+            // This instruction just calls itself: it's an infinitely
+            // recursive program.
+            0x08000000, // CALL 0
+            0x08000000, // CALL 0
+        ];
+        self.dcrypto.write_instructions(&INSTRUCTIONS, 0, 2);
+        self.dcrypto.call_imem(0);
+    }
+
+    // A PC stack overflow raises two interrupts, first an overflow then
+    // a trap. 
+    fn complete_test_stack(&self, error: ReturnCode, fault: ProgramFault) {
+        if error == ReturnCode::FAIL && fault == ProgramFault::StackOverflow {
+            println!("DCRYPTO pass: Program completed with fault {:?}.", fault);
+        } else if error == ReturnCode::FAIL && fault == ProgramFault::Trap {
+            println!("DCRYPTO pass: Program completed with fault {:?}.", fault);
+            self.case.set(TestCase::None);
+        }
+        else {
+            println!("DCRYPTO fail: program completed with ReturnCode {:?} and fault {:?}.", error, fault);
+        }
+    }
 }
 
 impl<'a> DcryptoClient<'a> for TestDcrypto<'a> {
-    fn execution_complete(&self, error: ReturnCode) {
-        println!("Execution of DCRYPTO toy program completed with ReturnCode {:?}.", error);
+    fn execution_complete(&self, error: ReturnCode, fault: ProgramFault) {
+        match self.case.get() {
+            TestCase::SuccessfulExecution => {
+                self.complete_test_exec(error, fault);
+                self.start_test_stack();
+            }
+            TestCase::StackError => {
+                self.complete_test_stack(error, fault);
+            }
+            TestCase::None => {
+                println!("DCRYPTO received execution complete for no test case.");
+            }
+        }
+        if self.case.get() == TestCase::None {
+            println!("DCRYPTO all tests passed!");
+        }
     }
 
     fn reset_complete(&self, _error: ReturnCode) {


### PR DESCRIPTION
This adds support for the dcrypto peripheral to Hotel. It also includes an example user-space library for running dcrypto programs, as well as trivial test application. I've tested that programs exit cleanly and errors are correctly propagated to userspace. However, currently the return values combine both ReturnCode as well as error codes from dcrypto: an improvement would be to separate the numeric values so they are not ambiguous. 

One issue that came up is the dcrypto peripheral memory does not support not-word-aligned byte loads and stores. So if you try to load/store byte 3, you load/store byte 0. This is an issue when copying to/from the data and instruction memories. since the userspace buffers may not be word aligned. The code currently manually assembles words from byte and spreads words into bytes. An improvement would be to use the .zip approach that Branden uses in the ADC capsule in the main tree.

To do item: test complex programs.
To do item: clean up u8/u32 conversion.
To do item: clean up error codes in userspace.